### PR TITLE
Add stub generation to fork mode

### DIFF
--- a/src/it/forkMixedCompile/invoker.properties
+++ b/src/it/forkMixedCompile/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals=clean test -Dmaven.plugin.validation=verbose
+#invoker.debug = true

--- a/src/it/forkMixedCompile/pom.xml
+++ b/src/it/forkMixedCompile/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.codehaus.gmavenplus</groupId>
+    <artifactId>gmavenplus-plugin-it-root</artifactId>
+    <version>testing</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>gmavenplus-plugin-it-fork-mixedCompile</artifactId>
+  <version>testing</version>
+  <name>GMavenPlus Plugin Fork Mixed Compile Test</name>
+  <description>This tests mixed Java/Groovy compilation in fork mode. This will fail for all versions of Groovy before 1.8.2.
+  </description>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>@groovyGroupId@</groupId>
+      <artifactId>groovy</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>@groovyGroupId@</groupId>
+      <artifactId>groovy-ant</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.gmavenplus</groupId>
+        <artifactId>gmavenplus-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>compile</id>
+            <goals>
+              <goal>addSources</goal>
+              <goal>addTestSources</goal>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>execute</id>
+            <phase>test</phase>
+            <goals>
+              <goal>execute</goal>
+            </goals>
+            <configuration>
+              <scripts>
+                <script><![CDATA[
+                  assert project.getCompileSourceRoots().toString().contains(File.separator + "src" + File.separator + "main" + File.separator + "java")
+                  assert project.getCompileSourceRoots().toString().contains(File.separator + "src" + File.separator + "main" + File.separator + "groovy")
+                  assert project.getCompileSourceRoots().toString().contains(File.separator + "target" + File.separator + "generated-sources" + File.separator + "groovy-stubs" + File.separator + "main")
+                  assert project.getTestCompileSourceRoots().toString().contains(File.separator + "src" + File.separator + "test" + File.separator + "java")
+                  assert project.getTestCompileSourceRoots().toString().contains(File.separator + "src" + File.separator + "test" + File.separator + "groovy")
+                  assert project.getTestCompileSourceRoots().toString().contains(File.separator + "target" + File.separator + "generated-sources" + File.separator + "groovy-stubs" + File.separator + "test")
+                ]]></script>
+              </scripts>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/forkMixedCompile/src/main/groovy/org/codehaus/gmavenplus/groovy/Grandchild.groovy
+++ b/src/it/forkMixedCompile/src/main/groovy/org/codehaus/gmavenplus/groovy/Grandchild.groovy
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.codehaus.gmavenplus.groovy
+
+import org.codehaus.gmavenplus.java.Child
+
+
+class Grandchild extends Child {
+
+    String yetAnotherMethod() {
+        return someMethod()
+    }
+
+}

--- a/src/it/forkMixedCompile/src/main/groovy/org/codehaus/gmavenplus/groovy/Parent.groovy
+++ b/src/it/forkMixedCompile/src/main/groovy/org/codehaus/gmavenplus/groovy/Parent.groovy
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.codehaus.gmavenplus.groovy
+
+
+class Parent {
+
+    String someMethod() {
+        return "Hello, world."
+    }
+
+}

--- a/src/it/forkMixedCompile/src/main/java/org/codehaus/gmavenplus/java/Child.java
+++ b/src/it/forkMixedCompile/src/main/java/org/codehaus/gmavenplus/java/Child.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.codehaus.gmavenplus.java;
+
+import org.codehaus.gmavenplus.groovy.Parent;
+
+
+public class Child extends Parent {
+
+    public String someOtherMethod() {
+        return someMethod();
+    }
+
+}

--- a/src/it/forkMixedCompile/src/test/java/org/codehaus/gmavenplus/TheTest.java
+++ b/src/it/forkMixedCompile/src/test/java/org/codehaus/gmavenplus/TheTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.codehaus.gmavenplus;
+
+import org.codehaus.gmavenplus.groovy.*;
+import org.codehaus.gmavenplus.java.*;
+import org.junit.Assert;
+import org.junit.Test;
+
+
+public class TheTest {
+
+    @Test
+    public void testYetAnotherMethod() {
+        Grandchild grandchild = new Grandchild();
+        Assert.assertEquals("Hello, world.", grandchild.yetAnotherMethod());
+    }
+
+}

--- a/src/main/java/org/codehaus/gmavenplus/mojo/AbstractCompileMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/AbstractCompileMojo.java
@@ -326,12 +326,18 @@ public abstract class AbstractCompileMojo extends AbstractGroovySourcesMojo {
 
     /**
      * Whether to run the compiler using {@code groovyc} in a separate process.
-     * <p>
+     *
      * {@code groovyc} will be search in {@code GROOVY_HOME/bin} first and then on the {@code PATH}.
      * If no executable was found, the compilation fails.
      */
-    @Parameter(property = "groovy.fork", defaultValue = "false")
+    @Parameter(defaultValue = "false")
     protected boolean fork;
+
+    /**
+     * Whether to enable joint compilation when invoking {@code groovyc} in a separate process.
+     */
+    @Parameter(defaultValue = "false")
+    protected boolean forkJointCompilation;
 
     /**
      * Performs compilation of compile mojos.
@@ -413,6 +419,10 @@ public abstract class AbstractCompileMojo extends AbstractGroovySourcesMojo {
 
         if (this.includeClasspath != IncludeClasspath.PROJECT_ONLY) {
             getLog().warn("Option 'includeClasspath' is requested but not supported yet with fork=true.");
+        }
+
+        if (true) {
+            args.add("--jointCompilation");
         }
 
         // missing:

--- a/src/main/java/org/codehaus/gmavenplus/mojo/AbstractGenerateStubsMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/AbstractGenerateStubsMojo.java
@@ -273,6 +273,15 @@ public abstract class AbstractGenerateStubsMojo extends AbstractGroovyStubSource
     protected IncludeClasspath includeClasspath;
 
     /**
+     * Whether to run the compiler using {@code groovyc} in a separate process.
+     *
+     * {@code groovyc} will be search in {@code GROOVY_HOME/bin} first and then on the {@code PATH}.
+     * If no executable was found, the compilation fails.
+     */
+    @Parameter(defaultValue = "false")
+    protected boolean fork;
+
+    /**
      * Performs the stub generation on the specified source files.
      *
      * @param stubSources     the sources to perform stub generation on
@@ -287,6 +296,11 @@ public abstract class AbstractGenerateStubsMojo extends AbstractGroovyStubSource
     protected synchronized void doStubGeneration(final Set<File> stubSources, final List<?> classpath, final File outputDirectory) throws ClassNotFoundException, InvocationTargetException, IllegalAccessException, InstantiationException, MalformedURLException {
         if (stubSources == null || stubSources.isEmpty()) {
             getLog().info("No sources specified for stub generation. Skipping.");
+            return;
+        }
+
+        if (fork) {
+            getLog().warn("Stub generation mojos are not compatible with running in fork mode. Skipping.");
             return;
         }
 


### PR DESCRIPTION
This isn't currently working. I think it's because the stubs get put in a temporary directory where they can't be referenced by the Java code.
```java
if (configuration.getJointCompilationOptions() != null
        && !configuration.getJointCompilationOptions().containsKey("stubDir")) {
    tmpDir = DefaultGroovyStaticMethods.createTempDir(null, "groovy-generated-", "-java-source");
    configuration.getJointCompilationOptions().put("stubDir", tmpDir);
}
```
https://github.com/apache/groovy/blob/542e1e5fbce7af9b4a39875b03ffda30c22409a7/src/main/java/org/codehaus/groovy/tools/FileSystemCompiler.java#L220-L224